### PR TITLE
Use vector instead of single var

### DIFF
--- a/include/scaledataparser.h
+++ b/include/scaledataparser.h
@@ -11,6 +11,7 @@
 #include <cerrno>
 #include <thread>
 #include <mutex>
+#include <vector>
 
 #include "utils.h"
 #include "serialdriver.h"
@@ -25,28 +26,26 @@ class ScaleDataParser
         ScaleDataParser(std::string path, int baud);
         ~ScaleDataParser();
         
-        void            CollectDataFromSerial();
-        void            ParseDataToJson();
-        void            RunParser();
+        void                        CollectDataFromSerial();
+        void                        ParseDataToJson();
+        void                        RunParser();
 
         // Return attribute methods
-        int             Baud(){ return baudRate; };
-        std::string     Port(){ return serialPort; };
+        int                         Baud(){ return baudRate; };
+        std::string                 Port(){ return serialPort; };
 
         
         
     private:
         // --------------- Private Attributes --------------- //
         // Configuration attributes
-        int             baudRate;
-        std::string     serialPort;
+        int                         baudRate;
+        std::string                 serialPort;
         
         // Serial data collection attributes
-        SerialDriver*   serialDriver; 
-        std::mutex      dataMutex;
-        std::string     serialData;
-        bool            newDataReady;
-        bool            dataProcessed;
+        SerialDriver*               serialDriver; 
+        std::mutex                  dataMutex;
+        std::vector<std::string>    serialDataList;
 
 
         // ----------------- Private Methods ---------------- //


### PR DESCRIPTION
- Using vector instead of var meant that the collection thread is completely independent from the parser processing time, theoretically improves speed.